### PR TITLE
Update populate-by-reference.js

### DIFF
--- a/populate-by-reference.js
+++ b/populate-by-reference.js
@@ -41,7 +41,6 @@ const populateByProxy = module.exports.populateByProxy = function populateByProx
    * Check if the object contains the $ref key and populate agains the correct collection
    */
   if (
-    typeof object === 'object' &&
     Object.keys(object).includes('$ref') &&
     Object.keys(object).includes('id')
   ) {
@@ -125,7 +124,6 @@ const populateByAssign = module.exports.populateByAssign = function populateByAs
    * Check if the object contains the $ref key and populate agains the correct collection
    */
   if (
-    typeof object === 'object' &&
     Object.keys(object).includes('$ref') &&
     Object.keys(object).includes('id')
   ) {


### PR DESCRIPTION
It's not necessary to check if the type is an object because you already checked in line (36, 127)